### PR TITLE
fix(format_font_family) do not double up on quotes

### DIFF
--- a/lib/css-purge.js
+++ b/lib/css-purge.js
@@ -2350,7 +2350,7 @@ function CSSPurge() {
 										if (
 											fontVal[k].indexOf(' ') != -1
 											&& (
-												fontVal[k].indexOf('"') == -1
+												fontVal[k].indexOf('"') == -1 && fontVal[k].indexOf('\'') == -1
 											)
 										) {
 											fontTmpVal += '"' + fontVal[k].trim() + '",';


### PR DESCRIPTION
Fix bug where if a font family name with spaces was wrapped in single quotes css-purge would add double quotes around the single quotes. Both quote styles are acceptable. Adding the extra quotes breaks the font-family so that it's no longer applied, and this avoids that happening.

Before change:
`.panel { font-family: 'my font'; }` becomes `.panel { font-family: "'my font'"; }`
After change:
`.panel { font-family: 'my font'; }` remains `.panel { font-family: 'my font'; }`